### PR TITLE
fix erroneous nvml access causing crash

### DIFF
--- a/src/machine.rs
+++ b/src/machine.rs
@@ -161,14 +161,17 @@ impl Machine {
             for n in 0..nvml.device_count().unwrap() {
                 let device = nvml.device_by_index(n).unwrap();
                 let mut processes = Vec::new();
-                for p in device.process_utilization_stats(None).unwrap() {
-                    processes.push(GraphicsProcessUtilization{
-                         pid: p.pid,
-                        gpu: p.sm_util,
-                        memory: p.mem_util,
-                        encoder: p.enc_util,
-                        decoder: p.dec_util
-                    });
+                let stats = device.process_utilization_stats(None);
+                if stats.is_ok() {
+                    for p in device.process_utilization_stats(None).unwrap() {
+                        processes.push(GraphicsProcessUtilization{
+                            pid: p.pid,
+                            gpu: p.sm_util,
+                            memory: p.mem_util,
+                            encoder: p.enc_util,
+                            decoder: p.dec_util
+                        });
+                    }
                 }
     
                 cards.push(GraphicsUsage {

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -163,7 +163,7 @@ impl Machine {
                 let mut processes = Vec::new();
                 let stats = device.process_utilization_stats(None);
                 if stats.is_ok() {
-                    for p in device.process_utilization_stats(None).unwrap() {
+                    for p in stats.unwrap() {
                         processes.push(GraphicsProcessUtilization{
                             pid: p.pid,
                             gpu: p.sm_util,


### PR DESCRIPTION
There was an unhandled error crashing applications when trying to access graphics_status method from this library, resulting in having to wrap calls into catch statements. This should fix those problems (though not the most pretty solution).