### PR TITLE
bugfix/Gracefully read the device tree

### DIFF
--- a/src/machine.rs
+++ b/src/machine.rs
@@ -112,12 +112,8 @@ impl Machine {
         
         // Getting the model
         let model_path = Path::new("/sys/firmware/devicetree/base/model");
-        let model = if model_path.exists() {
-            Some(std::fs::read_to_string(model_path).unwrap())
-        } else {
-            None
-        };
-        
+        let model = std::fs::read_to_string(model_path).ok();
+
         let vaapi = Path::new("/dev/dri/renderD128").exists();
 
         SystemInfo {


### PR DESCRIPTION
This PR fixes a bug in machine-info where reading the device model from /sys/firmware/devicetree/base/model on certain Android devices could cause the library to fail entirely if the file exists but cannot be read due to permission restrictions.

Currently, the code checks for the existence of the path before reading:
`let model_path = Path::new("/sys/firmware/devicetree/base/model");
let model = if model_path.exists() {
    Some(std::fs::read_to_string(model_path).unwrap())
} else {
    None
};`
This approach has two issues:
False sense of safety – Path::exists() returning true does not guarantee the file can be read, using .unwrap() will panic if permissions are denied or if any I/O error occurs. On some Android devices, /sys/firmware/devicetree/base/model exists but cannot be read. This caused machine-info to panic instead of handling the error gracefully.
Redundancy - Logically it is not necessary to detect if the path exist before trying to read it. Using .ok() to handle any kinds if read failure.
